### PR TITLE
fix: Rename coze-sdk to coze and release coze-api v0.1.4 with API fixes

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -39,7 +39,7 @@
     <parent>
         <groupId>com.coze</groupId>
         <artifactId>coze-sdk</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
     </parent>
 
     <artifactId>coze-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -38,7 +38,7 @@
 
     <parent>
         <groupId>com.coze</groupId>
-        <artifactId>coze-sdk</artifactId>
+        <artifactId>coze</artifactId>
         <version>0.1.0</version>
     </parent>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -43,7 +43,7 @@
     </parent>
 
     <artifactId>coze-api</artifactId>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
 
     <scm>
         <connection>scm:git:git://github.com/coze-dev/coze-java.git</connection>

--- a/api/src/main/java/com/coze/openapi/client/connversations/message/CreateMessageReq.java
+++ b/api/src/main/java/com/coze/openapi/client/connversations/message/CreateMessageReq.java
@@ -40,7 +40,7 @@ public class CreateMessageReq extends BaseReq {
    * The content of the message, supporting pure text, multimodal (mixed input of text, images, files),
    * cards, and various types of content.
    * */
-  @NonNull private String content;
+  private String content;
 
   /*
    * The type of message content.

--- a/api/src/main/java/com/coze/openapi/client/connversations/message/ListMessageReq.java
+++ b/api/src/main/java/com/coze/openapi/client/connversations/message/ListMessageReq.java
@@ -26,7 +26,8 @@ public class ListMessageReq extends BaseReq {
 
   /** The sorting method for the message list. */
   @JsonProperty("order")
-  private String order;
+  @Builder.Default
+  private String order = Sort.DESC.getValue();
 
   /** The ID of the Chat. */
   @JsonProperty("chat_id")
@@ -47,8 +48,4 @@ public class ListMessageReq extends BaseReq {
 
   @JsonProperty("bot_id")
   private String botID;
-
-  @JsonProperty("order")
-  @Builder.Default
-  private Sort sort = Sort.DESC;
 }

--- a/api/src/main/java/com/coze/openapi/client/workspace/model/Workspace.java
+++ b/api/src/main/java/com/coze/openapi/client/workspace/model/Workspace.java
@@ -3,11 +3,15 @@ package com.coze.openapi.client.workspace.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Workspace {
   @JsonProperty("id")
   private String id;

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>com.coze</groupId>
-        <artifactId>coze-sdk</artifactId>
+        <artifactId>coze</artifactId>
         <version>0.1.0</version>
     </parent>
 
@@ -16,7 +16,6 @@
         <dependency>
             <groupId>com.coze</groupId>
             <artifactId>coze-api</artifactId>
-            <version>0.1.1</version>
         </dependency>
     </dependencies>
 </project> 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.coze</groupId>
         <artifactId>coze-sdk</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
     </parent>
 
     <artifactId>coze-example</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.coze</groupId>
-    <artifactId>coze-sdk</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <artifactId>coze</artifactId>
+    <version>0.1.0</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -21,6 +21,16 @@
         <lombok.version>1.18.24</lombok.version>
         <junit.version>5.8.2</junit.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.coze</groupId>
+                <artifactId>coze-api</artifactId>
+                <version>0.1.4</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
- Rename 'coze-sdk' to 'coze' of the project
- Bump coze-api version to 0.1.4
- Fix various API issues in coze-api