### PR TITLE
feat: Support need_play_prologue and prologue_content in ChatUpdateEventData

### DIFF
--- a/api/src/main/java/com/coze/openapi/client/websocket/event/model/ChatUpdateEventData.java
+++ b/api/src/main/java/com/coze/openapi/client/websocket/event/model/ChatUpdateEventData.java
@@ -24,4 +24,10 @@ public class ChatUpdateEventData {
 
   @JsonProperty("turn_detection")
   private TurnDetection turnDetection;
+
+  @JsonProperty("need_play_prologue")
+  private Boolean needPlayPrologue;
+
+  @JsonProperty("prologue_content")
+  private String prologueContent;
 }


### PR DESCRIPTION
Add support to the following params in streaming chat event update data, changes have been verified to be valid:
- data.need_play_prologue
- data.prologue_content

Reference doc: https://www.coze.cn/open/docs/developer_guides/streaming_chat_event

