### PR TITLE
fix: 修复文件名为空导致的异常

### DIFF
--- a/api/src/main/java/com/coze/openapi/client/audio/transcriptions/CreateTranscriptionsReq.java
+++ b/api/src/main/java/com/coze/openapi/client/audio/transcriptions/CreateTranscriptionsReq.java
@@ -33,7 +33,7 @@ public class CreateTranscriptionsReq extends BaseReq {
   }
 
   public static CreateTranscriptionsReq of(File file) {
-    return CreateTranscriptionsReq.builder().file(file).build();
+    return CreateTranscriptionsReq.builder().file(file).fileName(file.getName()).build();
   }
 
   public static CreateTranscriptionsReq of(String filePath) {


### PR DESCRIPTION
- 在 CreateTranscriptionsReq 类中的 of(File file) 方法中增加了设置文件名的逻辑
- 解决TranscriptionService中获取文件名为空，导致的接口返回 {"detail":{"logid":"xxxx"},"code":4000,"msg":"The parameter file is invalid. It should follow the format: file. Please review your input."}