### PR TITLE
chore: Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/coze-dev/coze-java/security/code-scanning/6](https://github.com/coze-dev/coze-java/security/code-scanning/6)

To fix the problem, add an explicit `permissions` block set to the least privilege at the job or workflow level.  
- In general, this is best done at the top of the workflow for clarity and maintainability.
- In this workflow, adding `permissions: contents: read` at the root level ensures all jobs and steps only receive minimal access to repository contents via the `GITHUB_TOKEN`.
- The block should be inserted between the workflow name and the `on:` or after `on:`, before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
