### PR TITLE
feat(audio): 添加 ASR 配置支持以增强语音转录功能

### DIFF
--- a/api/src/main/java/com/coze/openapi/client/audio/rooms/model/RoomConfig.java
+++ b/api/src/main/java/com/coze/openapi/client/audio/rooms/model/RoomConfig.java
@@ -20,6 +20,7 @@ public class RoomConfig {
   }
 
   @JsonProperty("room_mode")
+  @Builder.Default
   private String roomMode = "";
 
   @JsonProperty("translate_config")

--- a/api/src/main/java/com/coze/openapi/client/websocket/event/model/AsrConfig.java
+++ b/api/src/main/java/com/coze/openapi/client/websocket/event/model/AsrConfig.java
@@ -19,5 +19,18 @@ public class AsrConfig {
   private String context;
 
   @JsonProperty("user_language")
-  private String userLanguage;
+  @Builder.Default
+  private String userLanguage = "common";
+
+  @JsonProperty("enable_ddc")
+  @Builder.Default
+  private Boolean enableDdc = true;
+
+  @JsonProperty("enable_itn")
+  @Builder.Default
+  private Boolean enableItn = true;
+
+  @JsonProperty("enable_punc")
+  @Builder.Default
+  private Boolean enablePunc = true;
 }

--- a/api/src/main/java/com/coze/openapi/client/websocket/event/model/TranscriptionsUpdateEventData.java
+++ b/api/src/main/java/com/coze/openapi/client/websocket/event/model/TranscriptionsUpdateEventData.java
@@ -12,4 +12,11 @@ import lombok.*;
 public class TranscriptionsUpdateEventData {
   @JsonProperty("input_audio")
   private InputAudio inputAudio;
+
+  @JsonProperty("asr_config")
+  private AsrConfig asrConfig;
+
+  public TranscriptionsUpdateEventData(InputAudio inputAudio) {
+    this.inputAudio = inputAudio;
+  }
 }

--- a/api/src/test/java/com/coze/openapi/utils/Utils.java
+++ b/api/src/test/java/com/coze/openapi/utils/Utils.java
@@ -10,6 +10,8 @@ public class Utils {
   private static final Headers commonHeader =
       Headers.of(
           new HashMap<String, String>() {
+            private static final long serialVersionUID = 1L;
+
             {
               put(LOG_HEADER, TEST_LOG_ID);
             }

--- a/example/src/main/java/example/websocket/audio/transcriptions/WebsocketTranscriptionsExample.java
+++ b/example/src/main/java/example/websocket/audio/transcriptions/WebsocketTranscriptionsExample.java
@@ -2,7 +2,6 @@ package example.websocket.audio.transcriptions;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
@@ -10,6 +9,7 @@ import com.coze.openapi.client.audio.common.AudioFormat;
 import com.coze.openapi.client.audio.speech.CreateSpeechReq;
 import com.coze.openapi.client.audio.speech.CreateSpeechResp;
 import com.coze.openapi.client.websocket.event.downstream.*;
+import com.coze.openapi.client.websocket.event.model.AsrConfig;
 import com.coze.openapi.client.websocket.event.model.InputAudio;
 import com.coze.openapi.client.websocket.event.model.TranscriptionsUpdateEventData;
 import com.coze.openapi.service.auth.TokenAuth;
@@ -27,7 +27,6 @@ public class WebsocketTranscriptionsExample {
   public static boolean isDone = false;
 
   private static class CallbackHandler extends WebsocketsAudioTranscriptionsCallbackHandler {
-    private final ByteBuffer buffer = ByteBuffer.allocate(1024 * 1024 * 10); // 分配 10MB 缓冲区
 
     public CallbackHandler() {
       super();
@@ -120,7 +119,15 @@ public class WebsocketTranscriptionsExample {
 
       InputAudio inputAudio =
           InputAudio.builder().sampleRate(24000).codec("pcm").format("wav").channel(2).build();
-      client.transcriptionsUpdate(new TranscriptionsUpdateEventData(inputAudio));
+
+      AsrConfig asrConfig =
+          AsrConfig.builder()
+              .hotWords(Arrays.asList("Coze", "AI"))
+              .context("Real-time transcription")
+              .userLanguage("en-US")
+              .build();
+
+      client.transcriptionsUpdate(new TranscriptionsUpdateEventData(inputAudio, asrConfig));
 
       try (InputStream inputStream = speechResp.getResponse().byteStream()) {
         byte[] buffer = new byte[1024];


### PR DESCRIPTION
- 在 AsrConfig 类中新增多个配置项，包括 enable_ddc、enable_itn 和 enable_punc，默认值设为 true
- 为 userLanguage 字段设置默认值 "common"
- 在 RoomConfig 中为 roomMode 设置默认空字符串并添加 Builder 默认注解
- 更新 TranscriptionsUpdateEventData 模型以支持 asrConfig 参数
- 扩展 WebSocket 客户端测试用例，验证带和不带 asrConfig 的事件处理逻辑
- 更新示例代码以演示如何传递 ASR 配置进行实时转录
- 修复测试工具类中的序列化版本 UID 缺失问题