### PR TITLE
feat: support workflow version in run requests

### DIFF
--- a/api/src/main/java/com/coze/openapi/client/workflows/run/RunWorkflowReq.java
+++ b/api/src/main/java/com/coze/openapi/client/workflows/run/RunWorkflowReq.java
@@ -55,4 +55,11 @@ public class RunWorkflowReq extends BaseReq {
    * */
   @JsonProperty("app_id")
   private String appID;
+
+  /*
+   * The version number of the workflow is only valid when the running workflow belongs to the
+   * resource library workflow. If no version number is specified, the latest version is used.
+   * */
+  @JsonProperty("workflow_version")
+  private String workflowVersion;
 }

--- a/api/src/test/java/com/coze/openapi/service/service/workflow/WorkFlowRunServiceTest.java
+++ b/api/src/test/java/com/coze/openapi/service/service/workflow/WorkFlowRunServiceTest.java
@@ -21,6 +21,8 @@ import com.coze.openapi.client.workflows.run.RunWorkflowResp;
 import com.coze.openapi.client.workflows.run.model.WorkflowEvent;
 import com.coze.openapi.client.workflows.run.model.WorkflowEventType;
 import com.coze.openapi.utils.Utils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.reactivex.subscribers.TestSubscriber;
 import okhttp3.MediaType;
@@ -30,6 +32,8 @@ import retrofit2.Response;
 import retrofit2.mock.Calls;
 
 public class WorkFlowRunServiceTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private String eventData =
       "id: 0\n"
@@ -155,6 +159,22 @@ public class WorkFlowRunServiceTest {
     assertEquals(100, result.getUsage().getTokenCount());
     assertEquals(50, result.getUsage().getInputCount());
     assertEquals(50, result.getUsage().getOutputCount());
+  }
+
+  @Test
+  void testRunWorkflowReqSerializesWorkflowVersion() throws Exception {
+    RunWorkflowReq req =
+        RunWorkflowReq.builder()
+            .workflowID("test_workflow_id")
+            .appID("test_app_id")
+            .workflowVersion("1.2.3")
+            .build();
+
+    JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(req));
+
+    assertEquals("1.2.3", json.get("workflow_version").asText());
+    assertEquals("test_workflow_id", json.get("workflow_id").asText());
+    assertEquals("test_app_id", json.get("app_id").asText());
   }
 
   @Test


### PR DESCRIPTION
## What changed

- add `workflowVersion` to `RunWorkflowReq`
- serialize it as `workflow_version`
- add a test to verify the request JSON includes `workflow_version`

## Why

The workflow run API supports `workflow_version`, but the Java SDK request model did not expose it, so callers could not specify a workflow version.

## Validation

- `env JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home PATH=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home/bin:$PATH mvn -Dmaven.repo.local=/tmp/coze-java-m2 -pl api -Dtest=WorkFlowRunServiceTest test`