### PR TITLE
fix: run required labels on pull_request_target

### DIFF
--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,6 +1,8 @@
 name: Required Labels
 on:
-  pull_request:
+  # Run on the base repository context so fork PRs can still post label reminders.
+  # This workflow does not check out or execute PR code; it only inspects PR metadata.
+  pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 jobs:
   label:

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: mheap/github-action-required-labels@v5
+      - uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe
         with:
           mode: minimum
           count: 1


### PR DESCRIPTION
## What changed

- switch the required-labels workflow trigger from `pull_request` to `pull_request_target`
- document why the workflow is safe to run in the base repository context

## Why

Fork-based PRs currently fail the `label` check with `Resource not accessible by integration` because the workflow tries to comment on the PR while running under the restricted `pull_request` token.

This workflow only inspects PR metadata and does not check out or execute PR code, so `pull_request_target` is the appropriate trigger.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/required-labels.yml"); puts "ok"'`